### PR TITLE
fix(reservations): keep cancellation tokens out of URLs

### DIFF
--- a/services/reservation-service.ts
+++ b/services/reservation-service.ts
@@ -12,6 +12,13 @@ import {
 } from "../models";
 
 export class ReservationService {
+  /**
+   * The cancellation capability must never become part of the request URL. URLs
+   * are retained by browser history, server/proxy logs, telemetry and referrers;
+   * this header is deliberately only attached to the two anonymous reservation
+   * capability calls below.
+   */
+  private static readonly CancelTokenHeader = "X-Reservation-Cancel-Token";
   private _requestService: RequestService;
 
   constructor(coreInitializer: ICoreInitializer) {
@@ -88,7 +95,7 @@ export class ReservationService {
   }
 
   public async GetByToken(token: string): Promise<ReservationPublicModel> {
-    const response = await this._requestService.GetRequest("/Reservation/by-token/" + token);
+    const response = await this._requestService.GetRequest("/Reservation/by-token", this.cancelTokenHeader(token));
     const parsed = this._requestService.TryParseResponse(response);
     if (parsed === undefined) {
       throw new Error("Failed to get reservation by token");
@@ -97,11 +104,15 @@ export class ReservationService {
   }
 
   public async Cancel(token: string): Promise<ReservationPublicModel> {
-    const response = await this._requestService.PostRequest("/Reservation/cancel/" + token);
+    const response = await this._requestService.PostRequest("/Reservation/cancel", undefined, this.cancelTokenHeader(token));
     const parsed = this._requestService.TryParseResponse(response);
     if (parsed === undefined) {
       throw new Error("Failed to cancel reservation");
     }
     return parsed;
+  }
+
+  private cancelTokenHeader(token: string): Record<string, string> {
+    return { [ReservationService.CancelTokenHeader]: token };
   }
 }

--- a/test/reservation-token-transport.test.mjs
+++ b/test/reservation-token-transport.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const reservationServicePath = new URL("../services/reservation-service.ts", import.meta.url);
+
+test("reservation cancellation tokens travel only in the dedicated request header", async () => {
+  const source = await readFile(reservationServicePath, "utf8");
+
+  assert.match(source, /CancelTokenHeader\s*=\s*"X-Reservation-Cancel-Token"/);
+  assert.match(source, /GetRequest\("\/Reservation\/by-token", this\.cancelTokenHeader\(token\)\)/);
+  assert.match(source, /PostRequest\("\/Reservation\/cancel", undefined, this\.cancelTokenHeader\(token\)\)/);
+
+  assert.doesNotMatch(source, /\/Reservation\/by-token\/"\s*\+\s*token/);
+  assert.doesNotMatch(source, /\/Reservation\/cancel\/"\s*\+\s*token/);
+  assert.doesNotMatch(source, /[?&]token=/i);
+});


### PR DESCRIPTION
## Summary
- sends anonymous reservation lookup/cancel capabilities in `X-Reservation-Cancel-Token`
- removes the token from URL paths so it cannot reach logs, history, telemetry, or referrers
- adds a regression test that rejects token-bearing reservation URLs

## Verification
- `node --test test/reservation-token-transport.test.mjs`